### PR TITLE
Remove id requirement from mention props

### DIFF
--- a/src/Mention/index.js
+++ b/src/Mention/index.js
@@ -16,14 +16,14 @@ export const replaceMentions = (string, mentions) => {
   });
 };
 export const userMentionType = PropTypes.shape({
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   userName: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   email: PropTypes.string.isRequired,
   avatarURL: PropTypes.string,
 });
 export const groupMentionType = PropTypes.shape({
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   groupName: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   avatarURL: PropTypes.string,


### PR DESCRIPTION
https://github.com/oneteam-dev/comuque-api/blob/master/doc/rest-api/mentions.md#get-mention-candidates

あたらしい api の response に key が含まれていないのと、mention を記入するのには特に必要ないという観点から、`isRequired` を外す調整。