### PR TITLE
Upgrade fstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oneteam",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Oneteam specific React components",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3294,8 +3294,8 @@ fstream-ignore@^1.0.5:
     minimatch "^3.0.0"
 
 fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"


### PR DESCRIPTION
目的
====

https://github.com/oneteam-dev/react-oneteam/network/alert/yarn.lock/fstream/open

fstream の脆弱性指摘が存在する。
指摘通り fstream 1.0.12 に upgrade する。